### PR TITLE
Incorporate hash-to-curve by reference

### DIFF
--- a/vrf.xml
+++ b/vrf.xml
@@ -460,7 +460,7 @@
                 Steps:
                 <list style="numbers">
                     <t>one_string = 0x01 = I2OSP(1, 1), a single octet with value 1</t>
-                    <t>EM = MGF1(alpha_string || I2OSP(k, 4) || I2OSP(n, k) || one_string, k - 1)</t>
+                    <t>EM = MGF1(one_string || I2OSP(k, 4) || I2OSP(n, k) || alpha_string, k - 1)</t>
                     <t>m = OS2IP(EM)</t>
                     <t>s = RSASP1(K, m)</t>
                     <t>pi_string = I2OSP(s, k)</t>
@@ -499,7 +499,7 @@
                 Steps:
                 <list style="numbers">
                     <t>two_string = 0x02 = I2OSP(2, 1), a single octet with value 2</t>
-                    <t>beta_string = Hash(pi_string || two_string)</t>
+                    <t>beta_string = Hash(two_string || pi_string)</t>
                     <t>Output beta_string</t>
                 </list>
             </t>
@@ -534,7 +534,7 @@
                     <t>m = RSAVP1((n, e), s)</t>
                     <t>EM = I2OSP(m, k - 1)</t>
                     <t>one_string = 0x01 = I2OSP(1, 1), a single octet with value 1</t>
-                    <t>EM' = MGF1(alpha_string || I2OSP(k, 4) || I2OSP(n, k) || one_string, k - 1)</t>
+                    <t>EM' = MGF1(one_string || I2OSP(k, 4) || I2OSP(n, k) ||  alpha_string, k - 1)</t>
                     <t>
                         If EM and EM' are equal, output ("VALID", RSAFDHVRF_proof_to_hash(pi_string));
                         else output "INVALID".
@@ -706,7 +706,7 @@
                     <t>If D is "INVALID", output "INVALID" and stop</t>
                     <t>(Gamma, c, s) = D</t>
                     <t>three_string = 0x03 = int_to_string(3, 1), a single octet with value 3 </t>
-                    <t>beta_string = Hash(point_to_string(cofactor * Gamma) || suite_string || three_string)</t>
+                    <t>beta_string = Hash(suite_string || three_string || point_to_string(cofactor * Gamma))</t>
                     <t>Output beta_string</t>
                 </list>
             </t>
@@ -825,7 +825,7 @@
                     <t>While H is "INVALID" or H is EC point at infinity:
                     <list style="letters">
                         <t>ctr_string = int_to_string(ctr, 1)</t>
-                        <t>hash_string = Hash(PK_string || alpha_string || ctr_string || suite_string || one_string)</t>
+                        <t>hash_string = Hash(suite_string || one_string || PK_string || alpha_string || ctr_string)</t>
                         <t>H = arbitrary_string_to_point(hash_string)</t>
                         <t>If H is not "INVALID" and cofactor > 1, set H = cofactor * H</t>
                         <t>ctr = ctr + 1</t>
@@ -886,10 +886,10 @@
                 The domain separation tag DST, a parameter to the hash-to-curve suite, SHALL be set to
             <list>
                 <t>
-                    "ECVRF_" || h2c_suite_ID_string || suite_string || one_string
+                    "ECVRF_" || h2c_suite_ID_string || suite_string
                 </t>
             </list>
-                where "ECVRF_" is represented as a 6-byte ASCII encoding (in hexadecimal, octets 45 43 56 52 46 5F) and one_string = 0x01 = int_to_string(1, 1), a single octet with value 1.
+                where "ECVRF_" is represented as a 6-byte ASCII encoding (in hexadecimal, octets 45 43 56 52 46 5F).
             </t>
             </section>
 
@@ -990,11 +990,11 @@
                 Steps:
                 <list style="numbers">
                     <t>two_string = 0x02 = int_to_string(2, 1), a single octet with value 2 </t>
-                    <t>Initialize str to the empty string</t>
+                    <t>Initialize str = suite_string || two_string </t>
                     <t>for PJ in [P1, P2, ... PM]:
                        <vspace/>str = str || point_to_string(PJ)
                     </t>
-                    <t>c_string = Hash(str || suite_string || two_string)</t>
+                    <t>c_string = Hash(str)</t>
                     <t>truncated_c_string = c_string[0]...c_string[n-1] 
                     <!--(first n octets of c_string)--></t>
                     <t>c = string_to_int(truncated_c_string)</t>
@@ -1514,15 +1514,28 @@
          to equal each other or to any queries made to the hash function for the same SK and 
          different alpha. This is indeed the case for the RSA-FDH-VRF defined in this document, because the first octets
          of the input to the hash function used in MGF1 and in proof_to_hash are different.
+     </t>
+
+     <t>
          This is also the case for the ECVRF ciphersuites defined in this document, because:
          <list style="symbols">
           <t>inputs to the hash function used during nonce_generation are unlikely to equal 
-          to inputs given to hash_to_curve, proof_to_hash, and hash_points. This
+          inputs used in hash_to_curve, proof_to_hash, and hash_points. This
           follows since nonce_generation inputs a secret to the hash function that is not used by 
           honest parties as input to any other hash function, and is not available to the adversary</t>
+
           <t>the second octet of the input to the hash function used in 
-          hash_to_curve, proof_to_hash, and
-          hash_points are all different</t>
+          proof_to_hash, hash_points, and hash_to_curve (try-and-increment variant)
+          are all different</t>
+
+          <t>suites that use ECVRF_hash_to_curve_h2c_suite entail additional hash invocations inside
+          the expand_message_xmd function defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>.
+          The input to the hash function inside expand_message_xmd takes one of two forms:
+          either it begins with an input block of zero octets (thus, it has a different second
+          octet from hash inputs in proof_to_hash and hash_points), or it begins with a value that is neither
+          used elsewhere by an honest party nor available to the adversary (thus, it is unlikely
+          that the input will equal inputs given in nonce_generation, proof_to_hash, or hash_points).</t>
+
          </list>
          
      </t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -1644,7 +1644,7 @@
         <?rfc include="reference.RFC.6234.xml"?>
         <?rfc include="reference.RFC.8032.xml"?>
         <?rfc include="reference.RFC.6979.xml"?>
-        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-05.xml"?>
+        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-07.xml"?>
 
 
         <reference anchor="FIPS-186-4" target = "https://csrc.nist.gov/publications/detail/fips/186/4/final">

--- a/vrf.xml
+++ b/vrf.xml
@@ -563,6 +563,17 @@
         </t>
         
         <t>
+            Notation used:
+            <list>
+                <t>Elliptic curve operations are written in additive notation, with P+Q denoting point addition and x*P denoting scalar multiplication of a point P by a scalar x</t>
+                <t>x^y - x raised to the power y</t>
+                <t>x*y - x multiplied by y</t>
+                <t>s || t - concatenation of octet strings s and t</t>
+            </list>
+        </t>
+
+        
+        <t>
             Fixed options (specified in <xref target="suites"/>):
             <list>
                 <t>F - finite field</t>
@@ -576,53 +587,36 @@
                 <t>B - generator of group G</t>
                 <t>Hash - cryptographic hash function</t>
                 <t>hLen - output length in octets of Hash; must be at least 2n</t>
-                <t>suite_string - a single nonzero octet specifying the ECVRF 
-                ciphersuite, which determines the above options</t>
+                <t>ECVRF_hash_to_curve - a function that hashes strings to an EC point.</t>
+                <t>ECVRF_nonce_generation - a function that derives a pseudorandom nonce
+                    from SK and the input as part of ECVRF proving.</t>
+                <t>suite_string - a single nonzero octet specifying the ECVRF
+                ciphersuite, which determines the above options as well as type conversions and parameter generation </t>
             </list>
 
         </t>
-        
         <t>
-            Notation and primitives used:
-            <list>
-                <t>Elliptic curve operations are written in additive notation, with P+Q denoting point addition and x*P denoting scalar multiplication of a point P by a scalar x</t>
-                <t>x^y - a raised to the power b</t>
-                <t>x*y - a multiplied by b</t>
-                <t>|| - octet string concatenation</t>
-                <t>ECVRF_hash_to_curve - collision resistant hash of strings
-                    to an EC point; options described in <xref target="ecvrfH2C" /> and specified in <xref target="suites"/>.</t>
-                <t>ECVRF_nonce_generation - derives a pseudorandom nonce
-                    from SK and the input as part of ECVRF proving.
-                    Specified in <xref target="suites"/></t>
-                <t>ECVRF_hash_points - collision resistant hash of EC points
-                    to an integer. Specified in <xref target="ecvrfHashPoints"/>.</t>
-            </list>
-        </t>
-        <t>
-            Type conversions:
+            Type conversions (specified in <xref target="suites"/>):
             <list>
                 <t>int_to_string(a, len) - conversion of nonnegative integer a to
-                    to octet string of length len as specified in <xref target="suites"/>.</t>
+                    to octet string of length len</t>
                 <t> string_to_int(a_string) - conversion of an octet string a_string
-                    to a nonnegative integer as specified in <xref target="suites"/>.</t>
-                <t>point_to_string - conversion of EC point to an ptLen-octet string
-                    as specified in <xref target="suites"/></t>
-                <t>string_to_point - conversion of an ptLen-octet string to EC point
-                    as specified in <xref target="suites"/>.
+                    to a nonnegative integer</t>
+                <t>point_to_string - conversion of EC point to an ptLen-octet string</t>
+                <t>string_to_point - conversion of an ptLen-octet string to EC point.
                     string_to_point returns INVALID if the octet string does not convert to a valid EC point.</t>
-                <t>arbitrary_string_to_point - conversion of an arbitrary octet string to an
-                    EC point as specified in <xref target="suites"/></t>
                 <t>
-                    Note that with certain software libraries 
-                    (for big integer and elliptic curve arithmetic), 
-                    the int_to_string and point_to_string conversions are not needed. 
-                    For example, in some implementations, EC point 
-                    operations will take octet strings as inputs and 
-                    produce octet strings as outputs, without introducing 
+                    Note that with certain software libraries
+                    (for big integer and elliptic curve arithmetic),
+                    the int_to_string and point_to_string conversions are not needed.
+                    For example, in some implementations, EC point
+                    operations will take octet strings as inputs and
+                    produce octet strings as outputs, without introducing
                     a separate elliptic curve point type.
                 </t>
             </list>
         </t>
+
 
           <t>
             Parameters used (the generation of these parameters is specified in <xref target="suites"/>):
@@ -670,7 +664,7 @@
                     <t>h_string = point_to_string(H)</t>
                     <t>Gamma = x*H</t>
                     <t>k = ECVRF_nonce_generation(SK, h_string)</t>
-                    <t>c = ECVRF_hash_points(H, Gamma, k*B, k*H)</t>
+                    <t>c = ECVRF_hash_points(H, Gamma, k*B, k*H) (see <xref target="ecvrfHashPoints"/>)</t>
                     <t>s = (k + c*x) mod q</t>
                     <t>pi_string = point_to_string(Gamma) || int_to_string(c, n) || int_to_string(s, qLen)</t>
                     <t>Output pi_string</t>
@@ -708,7 +702,7 @@
             <t>
                 Steps:
                 <list style="numbers">
-                    <t>D = ECVRF_decode_proof(pi_string)</t>
+                    <t>D = ECVRF_decode_proof(pi_string) (see <xref target="ecvrfDecodeProof"/>)</t>
                     <t>If D is "INVALID", output "INVALID" and stop</t>
                     <t>(Gamma, c, s) = D</t>
                     <t>three_string = 0x03 = int_to_string(3, 1), a single octet with value 3 </t>
@@ -743,13 +737,13 @@
             <t>
                 Steps:
                 <list style="numbers">
-                    <t>D = ECVRF_decode_proof(pi_string)</t>
+                    <t>D = ECVRF_decode_proof(pi_string) (see <xref target="ecvrfDecodeProof"/>)</t>
                     <t>If D is "INVALID", output "INVALID" and stop</t>
                     <t>(Gamma, c, s) = D</t>
                     <t>H = ECVRF_hash_to_curve(Y, alpha_string)</t>
                     <t>U = s*B - c*Y</t>
                     <t>V = s*H - c*Gamma</t>
-                    <t>c' = ECVRF_hash_points(H, Gamma, U, V)</t>
+                    <t>c' = ECVRF_hash_points(H, Gamma, U, V) (see <xref target="ecvrfHashPoints"/>)</t>
                     <t>
                         If c and c' are equal, output ("VALID", ECVRF_proof_to_hash(pi_string));
                         else output "INVALID"
@@ -771,7 +765,7 @@
             <xref target="prehash" /> for further discussion.
             </t>
 
-            <t>The algorithms in this section are not compatible with each other; the choice of algorithm is made in <xref target="suites"/>.</t>
+            <t>This section specifies a number of such algorithms, which are not compatible with each other. The choice of a particular algorithm from the options specified in this section is made in <xref target="suites"/>.</t>
             
             <section title="ECVRF_hash_to_curve_try_and_increment" anchor="ecvrfH2C1">
             
@@ -812,6 +806,14 @@
                     <t>H - hashed value, a finite EC point in G </t>
                 </list>
             </t>
+            <t>
+                Fixed option  (specified in <xref target="suites"/>):
+                <list>
+                <t>arbitrary_string_to_point - conversion of an arbitrary octet string to an
+                    EC point.</t>
+                </list>
+            </t>
+
             
             <t>
                 Steps:
@@ -835,16 +837,19 @@
             
             </section>
 
-            <section title="ECVRF_hash_to_curve_h2csuite" anchor="h2csuite">
+            <section title="ECVRF_hash_to_curve_h2c_suite" anchor="h2csuite">
 
-            <t>The ECVRF_hash_to_curve_h2csuite(Y, alpha_string) algorithm
-                implements ECVRF_hash_to_curve using
-                a hash-to-curve suite as defined in
+            <t>The ECVRF_hash_to_curve_h2c_suite(Y, alpha_string) algorithm
+                implements ECVRF_hash_to_curve using one of the several
+                hash-to-curve options defined in
                 <xref target="I-D.irtf-cfrg-hash-to-curve"/>.
+                The specific choice of the hash-to-curve option
+                (called Suite ID in <xref target="I-D.irtf-cfrg-hash-to-curve"/>)
+                is given by the h2c_suite_ID_string parameter.
             </t>
 
             <t>
-                ECVRF_hash_to_curve_h2csuite(Y, alpha_string)
+                ECVRF_hash_to_curve_h2c_suite(Y, alpha_string)
             </t>
             <t>
                 Input:
@@ -861,9 +866,9 @@
                 </list>
             </t>
             <t>
-                Fixed options (specified in <xref target="suites"/>):
+                Fixed option (specified in <xref target="suites"/>):
                 <list>
-                    <t>h2cSuite - a hash-to-curve suite ID (see discussion below)</t>
+                    <t>h2c_suite_ID_string - a hash-to-curve suite ID, encoded in ASCII (see discussion below)</t>
                 </list>
             </t>
             <t>
@@ -876,26 +881,25 @@
                     <t>Output H</t>
                 </list>
             </t>
-            <t>The encode function is provided by the hash-to-curve suite whose ID is h2cSuite.
-                For more details, see <xref target="I-D.irtf-cfrg-hash-to-curve"/>, Section 8.
-                The domain separation tag DST, a parameter to the hash-to-curve suite, is
-            </t>
-            <t>
-            "ECVRF_" || h2csuite_string || suite_string || one_string
-            </t>
-            <t>
-                where "ECVRF_" is an ASCII string literal,
-                suite_string is a single octet,
-                one_string = 0x01 = int_to_string(1, 1), a single octet with value 1,
-                and h2csuite_string is the ASCII encoding of the h2cSuite option value.
+            <t>The encode function is provided by the hash-to-curve suite whose ID is h2c_suite_ID_string, as specified in
+                <xref target="I-D.irtf-cfrg-hash-to-curve"/>, Section 8.
+                The domain separation tag DST, a parameter to the hash-to-curve suite, SHALL be set to
+            <list>
+                <t>
+                    "ECVRF_" || h2c_suite_ID_string || suite_string || one_string
+                </t>
+            </list>
+                where "ECVRF_" is represented as a 6-byte ASCII encoding (in hexadecimal, octets 45 43 56 52 46 5F) and one_string = 0x01 = int_to_string(1, 1), a single octet with value 1.
             </t>
             </section>
 
         </section>
         <section title="ECVRF Nonce Generation" anchor="ecvrfNonceGeneration">
         
-        <t>The following subroutines generate the 
-        nonce value k in a deterministic pseudorandom fashion.</t>
+        <t>The following algorithms generate the
+        nonce value k in a deterministic pseudorandom fashion.
+            This section specifies a number of such algorithms, which are not compatible with each other.
+            The choice of a particular algorithm from the options specified in this section is made in Section 5.5.</t>
         
             <section title = "ECVRF Nonce Generation From RFC 6979" anchor="nonceP256">
                 
@@ -1002,7 +1006,7 @@
                    
         </section>
 
-        <section title="ECVRF Decode Proof">
+        <section title="ECVRF Decode Proof" anchor="ecvrfDecodeProof">
             <t>
                 ECVRF_decode_proof(pi_string)
             </t>
@@ -1047,7 +1051,7 @@
         <t>This document defines ECVRF-P256-SHA256-TAI as follows:
         <list style="symbols">
         <t>
-        suite_string = 0x01 = int_to_string(1, 1). </t>
+        suite_string = 0x01 = int_to_string(1, 1), a single octet with value 1.</t>
         <t>
             The EC group G is the NIST P-256 elliptic curve, with curve parameters
             as specified in <xref target="FIPS-186-4"></xref> (Section D.1.2.3)
@@ -1085,40 +1089,33 @@
             the octet string does not decode to an EC point.
         </t>
         
-        <t> arbitrary_string_to_point(s) = string_to_point(0x02 || s)
-        (where 0x02 is a single 
-        octet with value 2, 0x02=int_to_string(2, 1)). The input s is a 32-octet string
-        and the output is either an EC point or "INVALID". </t>
         
         <t>
             The hash function Hash is SHA-256 as specified in <xref target="RFC6234"/>, with hLen = 32.
         </t>
         <t>
-            The ECVRF_hash_to_curve function is as specified in <xref target="ecvrfH2C1"/>.
+            The ECVRF_hash_to_curve function is as specified in <xref target="ecvrfH2C1"/>, with arbitrary_string_to_point(s) = string_to_point(0x02 || s)
+                  (where 0x02 is a single
+                  octet with value 2, 0x02=int_to_string(2, 1)). The input s to arbitrary_string_to_point is a 32-octet string
+                  and the output is either an EC point or "INVALID".
         </t>
         </list>
         </t>
         
-        <t>This document defines ECVRF-P256-SHA256-SWU as follows:
-            
-            <list style="symbols">
-                <t> This ciphersuite is identical to ECVRF-P256-SHA256-TAI except that
-                    the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
-                    with h2cSuite = P256_XMD:SHA-256_SSWU_NU_
-                    and suite_string = 0x02 = int_to_string(2, 1).
-                </t>
-                <t>
-                    The hash-to-curve suite P256_XMD:SHA-256_SSWU_NU_ is defined in
-                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.1.
-                </t>
-            </list>
+        <t>This document defines ECVRF-P256-SHA256-SWU as identical to ECVRF-P256-SHA256-TAI, except that:
+                <list style="symbols">
+                    <t> suite_string = 0x02 = int_to_string(2, 1), a single octet with value 2.</t>
+                    <t>the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
+                        with h2c_suite_ID_string = P256_XMD:SHA-256_SSWU_NU_
+                        (the suite is defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.1)</t>
+                </list>
         </t>
 
         
         <t>This document defines ECVRF-EDWARDS25519-SHA512-TAI as follows:
         <list style="symbols">
         <t>
-        suite_string = 0x03 = int_to_string(3, 1). </t>
+        suite_string = 0x03 = int_to_string(3, 1), a single octet with value 3. </t>
         <t>
             The EC group G is the edwards25519
             elliptic curve with parameters defined in Table 1 of
@@ -1153,28 +1150,26 @@
             the octet string does not decode to an EC point.
         </t>
 
-        <t>arbitrary_string_to_point(s) = string_to_point(s[0]...s[31])</t>
 
         <t>
             The hash function Hash is SHA-512 as specified in <xref target="RFC6234"/>, with hLen = 64.
         </t>
         <t>
-            The ECVRF_hash_to_curve function is as specified in <xref target="ecvrfH2C1"/>.
+            The ECVRF_hash_to_curve function is as specified in <xref target="ecvrfH2C1"/>, with arbitrary_string_to_point(s) = string_to_point(s[0]...s[31]).
         </t>
         </list>
         </t>
    
-   <t>This document defines ECVRF-EDWARDS25519-SHA512-Elligator2 as follows:
+   <t>This document defines ECVRF-EDWARDS25519-SHA512-Elligator2 as identical to ECVRF-EDWARDS25519-SHA512-TAI, except:
     
         <list style="symbols">
-        <t> This ciphersuite is identical to ECVRF-EDWARDS25519-SHA512-TAI except that
-            the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
-            with h2cSuite = edwards25519_XMD:SHA-512_ELL2_NU_
-            and suite_string = 0x04 = int_to_string(4, 1).
-        </t>
         <t>
-            The hash-to-curve suite edwards25519_XMD:SHA-512_ELL2_NU_ is defined in
-            <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.4.
+            suite_string = 0x04 = int_to_string(4, 1), a single octet with value 4.
+        </t>
+        <t>the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/> with
+            h2c_suite_ID_string = edwards25519_XMD:SHA-512_ELL2_NU_
+            (the suite is defined in
+            <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.4.)
         </t>
         </list>
         </t>
@@ -1649,6 +1644,8 @@
         <?rfc include="reference.RFC.6234.xml"?>
         <?rfc include="reference.RFC.8032.xml"?>
         <?rfc include="reference.RFC.6979.xml"?>
+        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-05.xml"?>
+
 
         <reference anchor="FIPS-186-4" target = "https://csrc.nist.gov/publications/detail/fips/186/4/final">
             <front>
@@ -1672,13 +1669,6 @@
 
     <references title="Informative References">
 
-        <reference anchor="ntb" target="http://www.shoup.net/ntb/ntb-v2.pdf">
-            <front>
-                <title>A Computational Introduction to Number Theory and Algebra</title>
-                <author initials="V." surname="Shoup"><organization /></author>
-                <date year="2008" />
-            </front>
-        </reference>
 
         <reference anchor="PWHVNRG17" target="https://eprint.iacr.org/2017/099.pdf">
             <front>
@@ -1706,50 +1696,6 @@
             <seriesInfo name="in" value="FOCS" />
         </reference>
 
-        <reference anchor="BHKT13" target = "https://elligator.cr.yp.to/elligator-20130828.pdf">
-            <front>
-                <title>Elligator: elliptic-curve points indistinguishable from uniform random strings</title>
-                <author initials = "D.J." surname = "Bernstein"><organization /></author>
-                <author initials = "M." surname = "Hamburg"><organization /></author>
-                <author initials = "A." surname = "Krasnova"><organization /></author>
-                <author initials = "T." surname = "Lange"><organization /></author>
-                <date year = "2013"/>
-            </front>
-            <seriesInfo name="in" value="ACM SIGSAC Conference on Computer and Communications Security (CCS)" />
-        </reference>
-        
-        <reference anchor="BCIMRT10" target = "https://eprint.iacr.org/2009/340">
-            <front>
-                <title>Efficient Indifferentiable Hashing into Ordinary Elliptic Curves</title>
-                <author initials= "E." surname="Brier"><organization /></author>
-                <author initials= "J.-S." surname="Coron"><organization /></author>
-                <author initials= "T." surname="Icart"><organization /></author>
-                <author initials= "D." surname="Madore"><organization /></author>
-                <author initials= "H." surname="Randriam"><organization /></author>
-                <author initials= "M." surname="Tibouchi"><organization /></author>
-                <date year="2010" />
-            </front>
-            <seriesInfo name="in" value="Advances in Cryptology - CRYPTO" />
-        </reference>
-        
-        <reference anchor="SW06" target = "https://works.bepress.com/andrew_shallue/1/">
-            <front>
-                <title>Construction of rational points on elliptic curves over finite fields</title>
-                <author initials ="A." surname = "Shallue"><organization /></author>
-                <author initials ="C." surname = "van de Woestijne"><organization /></author>
-                <date year = "2006" />
-            </front>
-        <seriesInfo name="in" value="Algorithmic Number Theory - ANTS" />
-        </reference>
-    
-        <reference anchor="Ulas07" target = "https://arxiv.org/abs/0706.1448">
-            <front>
-                <title>Rational points on certain hyperelliptic curves over finite fields</title>
-                <author initials ="M." surname = "Ulas"><organization /></author>
-                <date year = "2007" />
-            </front>
-        <seriesInfo name="in" value="Bull. Polish Acad. Sci. Math." />
-        </reference>
         
         <reference anchor = "X25519" target = "https://cr.yp.to/ecdh.html#validate">
             <front>
@@ -1786,7 +1732,6 @@
 
         <?rfc include="reference.I-D.vcelak-nsec5.xml"?>
 
-        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-05.xml"?>
 
     <reference anchor = "ANSI.X9-62-2005">
         <front>
@@ -1801,6 +1746,7 @@
     
     
     <section title="Test Vectors for the ECVRFs">
+        <t>THESE TEST VECTORS ARE OUT OF DATE GIVEN THE CHANGES TO THE SPECIFICATION</t>
         <t>The test vectors in this section were genereated using the reference implementation at <eref target ="https://github.com/reyzin/ecvrf" />.</t>
         <section title="ECVRF-P256-SHA256-TAI">
             <t>These two example secret keys and messages are taken from Appendix A.2.5 of <xref target="RFC6979"/>.</t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -666,7 +666,7 @@
                     <t>Use SK to derive the VRF secret scalar x and the VRF public key Y = x*B
                         <vspace/>(this derivation depends on the ciphersuite, as per  <xref target="suites"/>;
                         <vspace/>these values can be cached, for example, after key generation, and need not be rederived each time)</t>
-                    <t>H = ECVRF_hash_to_curve(suite_string, Y, alpha_string)</t>
+                    <t>H = ECVRF_hash_to_curve(Y, alpha_string)</t>
                     <t>h_string = point_to_string(H)</t>
                     <t>Gamma = x*H</t>
                     <t>k = ECVRF_nonce_generation(SK, h_string)</t>
@@ -746,7 +746,7 @@
                     <t>D = ECVRF_decode_proof(pi_string)</t>
                     <t>If D is "INVALID", output "INVALID" and stop</t>
                     <t>(Gamma, c, s) = D</t>
-                    <t>H = ECVRF_hash_to_curve(suite_string, Y, alpha_string)</t>
+                    <t>H = ECVRF_hash_to_curve(Y, alpha_string)</t>
                     <t>U = s*B - c*Y</t>
                     <t>V = s*H - c*Gamma</t>
                     <t>c' = ECVRF_hash_points(H, Gamma, U, V)</t>
@@ -776,7 +776,7 @@
             <section title="ECVRF_hash_to_curve_try_and_increment" anchor="ecvrfH2C1">
             
             <t>
-            The following ECVRF_hash_to_curve_try_and_increment(suite_string, Y, alpha_string) algorithm
+            The following ECVRF_hash_to_curve_try_and_increment(Y, alpha_string) algorithm
             implements ECVRF_hash_to_curve in a simple and
             generic way that works for any elliptic curve. 
             </t>
@@ -797,12 +797,11 @@
             </t>
             
             <t>
-                ECVRF_hash_to_try_and_increment(suite_string, Y, alpha_string)
+                ECVRF_hash_to_try_and_increment(Y, alpha_string)
             </t>
             <t>
                 Input:
                 <list>
-                    <t>suite_string - a single octet specifying ECVRF ciphersuite. </t>
                     <t>Y - public key, an EC point</t>
                     <t>alpha_string - value to be hashed, an octet string</t>
                 </list>
@@ -838,19 +837,18 @@
 
             <section title="ECVRF_hash_to_curve_h2csuite" anchor="h2csuite">
 
-            <t>The ECVRF_hash_to_curve_h2csuite(suite_string, Y, alpha_string) algorithm
+            <t>The ECVRF_hash_to_curve_h2csuite(Y, alpha_string) algorithm
                 implements ECVRF_hash_to_curve using
                 a hash-to-curve suite as defined in
                 <xref target="I-D.irtf-cfrg-hash-to-curve"/>.
             </t>
 
             <t>
-                ECVRF_hash_to_curve_h2csuite(suite_string, Y, alpha_string)
+                ECVRF_hash_to_curve_h2csuite(Y, alpha_string)
             </t>
             <t>
                 Input:
                 <list>
-                    <t>suite_string - a single octet specifying ECVRF ciphersuite. </t>
                     <t>alpha_string - value to be hashed, an octet string</t>
                     <t>Y - public key, an EC point</t>
                 </list>

--- a/vrf.xml
+++ b/vrf.xml
@@ -1108,6 +1108,10 @@
                     with h2cSuite = P256-SHA256-SSWU-NU-
                     and suite_string = 0x02 = int_to_string(2, 1).
                 </t>
+                <t>
+                    The hash-to-curve suite P256-SHA256-SSWU-NU- is defined in
+                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.2.
+                </t>
             </list>
         </t>
 
@@ -1170,9 +1174,9 @@
             and suite_string = 0x04 = int_to_string(4, 1).
         </t>
         <t>
-            The suite edwards25519-SHA512-EDELL2-NU- is identical to the suite
-            edwards25519-SHA256-EDELL2-NU- defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>,
-            Section 8, except that the hash function H is SHA-512 rather than SHA-256.
+            The hash-to-curve suite edwards25519-SHA512-EDELL2-NU- is identical to the suite
+            edwards25519-SHA256-EDELL2-NU- defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>
+            Section 8.5, except that the hash function H is SHA-512 rather than SHA-256.
         </t>
         </list>
         </t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -883,10 +883,10 @@
                 The domain separation tag DST, a parameter to the hash-to-curve suite, is
             </t>
             <t>
-            "ECVRF_" || suite_string || "_" || h2csuite_string || "_"
+            "ECVRF_V01_" || suite_string || "_" || h2csuite_string || "_"
             </t>
             <t>
-                where "ECVRF_" and "_" are ASCII string literals,
+                where "ECVRF_V01_" and "_" are ASCII string literals,
                 suite_string is a single octet,
                 and h2csuite_string is the ASCII encoding of the h2cSuite option value.
             </t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -1104,12 +1104,12 @@
             <list style="symbols">
                 <t> This ciphersuite is identical to ECVRF-P256-SHA256-TAI except that
                     the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
-                    with h2cSuite = P256-SHA256-SSWU-NU-
+                    with h2cSuite = P256_XMD:SHA-256_SSWU_NU_
                     and suite_string = 0x02 = int_to_string(2, 1).
                 </t>
                 <t>
-                    The hash-to-curve suite P256-SHA256-SSWU-NU- is defined in
-                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.3.
+                    The hash-to-curve suite P256_XMD:SHA-256_SSWU_NU_ is defined in
+                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.1.
                 </t>
             </list>
         </t>
@@ -1169,13 +1169,12 @@
         <list style="symbols">
         <t> This ciphersuite is identical to ECVRF-EDWARDS25519-SHA512-TAI except that
             the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
-            with h2cSuite = edwards25519-SHA512-EDELL2-NU-
+            with h2cSuite = edwards25519_XMD:SHA-512_ELL2_NU_
             and suite_string = 0x04 = int_to_string(4, 1).
         </t>
         <t>
-            The hash-to-curve suite edwards25519-SHA512-EDELL2-NU- is identical to the suite
-            edwards25519-SHA256-EDELL2-NU- defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>
-            Section 8.6, except that the hash function H is SHA-512 rather than SHA-256.
+            The hash-to-curve suite edwards25519_XMD:SHA-512_ELL2_NU_ is defined in
+            <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.4.
         </t>
         </list>
         </t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -712,7 +712,7 @@
                     <t>If D is "INVALID", output "INVALID" and stop</t>
                     <t>(Gamma, c, s) = D</t>
                     <t>three_string = 0x03 = int_to_string(3, 1), a single octet with value 3 </t>
-                    <t>beta_string = Hash(suite_string || three_string || point_to_string(cofactor * Gamma))</t>
+                    <t>beta_string = Hash(point_to_string(cofactor * Gamma) || suite_string || three_string)</t>
                     <t>Output beta_string</t>
                 </list>
             </t>
@@ -823,7 +823,7 @@
                     <t>While H is "INVALID" or H is EC point at infinity:
                     <list style="letters">
                         <t>ctr_string = int_to_string(ctr, 1)</t>
-                        <t>hash_string = Hash(suite_string || one_string || PK_string || alpha_string || ctr_string)</t>
+                        <t>hash_string = Hash(PK_string || alpha_string || ctr_string || suite_string || one_string)</t>
                         <t>H = arbitrary_string_to_point(hash_string)</t>
                         <t>If H is not "INVALID" and cofactor > 1, set H = cofactor * H</t>
                         <t>ctr = ctr + 1</t>
@@ -870,9 +870,7 @@
                 Steps
                 <list style="numbers">
                     <t>PK_string = point_to_string(Y)</t>
-                    <t>one_string = 0x01 = int_to_string(1, 1)
-                    <vspace/>(a single octet with value 1) </t>
-                    <t>string_to_hash = suite_string || one_string || PK_string || alpha_string</t>
+                    <t>string_to_hash = PK_string || alpha_string</t>
                     <t>H = encode(string_to_hash)
                     <vspace/>(the encode function is discussed below) </t>
                     <t>Output H</t>
@@ -883,11 +881,12 @@
                 The domain separation tag DST, a parameter to the hash-to-curve suite, is
             </t>
             <t>
-            "ECVRF_V01_" || suite_string || "_" || h2csuite_string || "_"
+            "ECVRF_" || h2csuite_string || suite_string || one_string
             </t>
             <t>
-                where "ECVRF_V01_" and "_" are ASCII string literals,
+                where "ECVRF_" is an ASCII string literal,
                 suite_string is a single octet,
+                one_string = 0x01 = int_to_string(1, 1), a single octet with value 1,
                 and h2csuite_string is the ASCII encoding of the h2cSuite option value.
             </t>
             </section>
@@ -957,7 +956,7 @@
                 <t>
                     Steps:
                     <list style="numbers">
-                        <t>hashed_sk_string = Hash (SK)</t>
+                        <t>hashed_sk_string = Hash(SK)</t>
                         <t>truncated_hashed_sk_string = hashed_sk_string[32]...hashed_sk_string[63]</t>
                         <t>k_string = Hash(truncated_hashed_sk_string || h_string)</t>
                         <t>k = string_to_int(k_string) mod q</t>
@@ -987,11 +986,11 @@
                 Steps:
                 <list style="numbers">
                     <t>two_string = 0x02 = int_to_string(2, 1), a single octet with value 2 </t>
-                    <t>Initialize str = suite_string || two_string </t>
+                    <t>Initialize str to the empty string</t>
                     <t>for PJ in [P1, P2, ... PM]:
                        <vspace/>str = str || point_to_string(PJ)
                     </t>
-                    <t>c_string = Hash(str)</t>
+                    <t>c_string = Hash(str || suite_string || two_string)</t>
                     <t>truncated_c_string = c_string[0]...c_string[n-1] 
                     <!--(first n octets of c_string)--></t>
                     <t>c = string_to_int(truncated_c_string)</t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -460,7 +460,7 @@
                 Steps:
                 <list style="numbers">
                     <t>one_string = 0x01 = I2OSP(1, 1), a single octet with value 1</t>
-                    <t>EM = MGF1(one_string || I2OSP(k, 4) || I2OSP(n, k) ||  alpha_string, k - 1)</t>
+                    <t>EM = MGF1(alpha_string || I2OSP(k, 4) || I2OSP(n, k) || one_string, k - 1)</t>
                     <t>m = OS2IP(EM)</t>
                     <t>s = RSASP1(K, m)</t>
                     <t>pi_string = I2OSP(s, k)</t>
@@ -499,7 +499,7 @@
                 Steps:
                 <list style="numbers">
                     <t>two_string = 0x02 = I2OSP(2, 1), a single octet with value 2</t>
-                    <t>beta_string = Hash(two_string || pi_string)</t>
+                    <t>beta_string = Hash(pi_string || two_string)</t>
                     <t>Output beta_string</t>
                 </list>
             </t>
@@ -534,7 +534,7 @@
                     <t>m = RSAVP1((n, e), s)</t>
                     <t>EM = I2OSP(m, k - 1)</t>
                     <t>one_string = 0x01 = I2OSP(1, 1), a single octet with value 1</t>
-                    <t>EM' = MGF1(one_string || I2OSP(k, 4) || I2OSP(n, k) ||  alpha_string, k - 1)</t>
+                    <t>EM' = MGF1(alpha_string || I2OSP(k, 4) || I2OSP(n, k) || one_string, k - 1)</t>
                     <t>
                         If EM and EM' are equal, output ("VALID", RSAFDHVRF_proof_to_hash(pi_string));
                         else output "INVALID".

--- a/vrf.xml
+++ b/vrf.xml
@@ -1110,7 +1110,7 @@
                 </t>
                 <t>
                     The hash-to-curve suite P256-SHA256-SSWU-NU- is defined in
-                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.2.
+                    <xref target="I-D.irtf-cfrg-hash-to-curve"/> Section 8.3.
                 </t>
             </list>
         </t>
@@ -1176,7 +1176,7 @@
         <t>
             The hash-to-curve suite edwards25519-SHA512-EDELL2-NU- is identical to the suite
             edwards25519-SHA256-EDELL2-NU- defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>
-            Section 8.5, except that the hash function H is SHA-512 rather than SHA-256.
+            Section 8.6, except that the hash function H is SHA-512 rather than SHA-256.
         </t>
         </list>
         </t>

--- a/vrf.xml
+++ b/vrf.xml
@@ -766,7 +766,7 @@
         
             <t>The ECVRF_hash_to_curve algorithm takes in the VRF input alpha
             and converts it to H, an EC point in G.
-            This algorithm is the only place the VRF input alpha is used in 
+            This algorithm is the only place the VRF input alpha is used
             for proving and verfying. See
             <xref target="prehash" /> for further discussion.
             </t>
@@ -835,213 +835,65 @@
             
             
             </section>
-            
-            
-            <section title="ECVRF_hash_to_curve_elligator2_25519" anchor="elligator2">
-            
-                <t> The following ECVRF_hash_to_curve_elligator2_25519(suite_string, Y, alpha_string)
-                algorithm implements ECVRF_hash_to_curve using the elligator2
-                algorithm from Section 5 of <xref target="BHKT13"/> (see also <xref target="I-D.irtf-cfrg-hash-to-curve"/>) exclusively for the edwards25519 elliptic curve. It can be implemented with running time that is independent of the input alpha (so-called "constant-time").
-                </t>
-                                
-                <t>
-                    ECVRF_hash_to_curve_elligator2_25519(suite_string, Y, alpha_string)
-                </t>
-                <t>
-                    Input:
-                    <list>
-                        <t>suite_string - a single octet specifying ECVRF ciphersuite. </t>
-                        <t>alpha_string - value to be hashed, an octet string</t>
-                        <t>Y - public key, an EC point</t>
-                    </list>
-                </t>
-                <t>
-                    Output:
-                    <list>
-                        <t>H - hashed value, a finite EC point in G
-                        </t>
-                    </list>
-                </t>
-                
-                <t> Fixed options:
-                    <list>
-                        <t> p = 2^255-19, the size of the finite field F, a prime, for edwards25519 and curve25519 curves</t>
-                        <t> A = 486662, Montgomery curve constant for curve25519 </t>
-                        <t> cofactor = 8, the cofactor for edwards25519 and curve25519 curves</t>
-                    </list>
-                </t>
-                
-                <t> Constraints on options:
-                    <list>
-                        <t> output length of Hash is at least 16n (i.e., 256) bits</t>
-                    </list>
-                </t>
-                
-                <t>
-                    Steps:
-                    <list style="numbers">
-                        <t>PK_string = point_to_string(Y)</t>
-                        <t>one_string = 0x01 = int_to_string(1, 1)
-                        <vspace/>(a single octet with value 1) </t>
-                        <t>hash_string = Hash(suite_string || one_string || PK_string || alpha_string )</t>
-                        <t>r_string = hash_string[0]...hash_string[31]
-                            <!--<vspace/>(first 32 octets of hash)--></t>
-                        <!--<t>oneTwentyEight_string = 0x80 = int_to_string(128, 1)
-                            <vspace/>(a single octet with value 128)</t> -->
-                        <t>oneTwentySeven_string = 0x7F = int_to_string(127, 1)
-                            <vspace/>(a single octet with value 127)</t>
-                        <!--<t>x0 = r_string[31] &amp; oneTwentyEight_string
-                            <vspace/>(where &amp; denotes the bit-wise AND)
-                            <vspace/>(this step saves highest-order bit of octet 31 in x0)</t>-->
-                        <t>r_string[31] = r_string[31] &amp; oneTwentySeven_string
-                            <vspace/>(this step clears the high-order bit of octet 31)</t>
-                        <t>r = string_to_int(r_string)</t>
-                        <t>u = - A / (1 + 2*(r^2) )  mod p
-                            <vspace/>(note: the inverse of (1+2*(r^2)) modulo p is guaranteed to exist)</t>
-                        <t>w = u * (u^2 + A*u + 1) mod p
-                            <vspace/>(this step evaluates the Montgomery equation for Curve25519)</t>
-                        <t>Let e equal the Legendre symbol of w and p
-                        <vspace/>(see note below on how to compute e)</t>
-                        <t>If e is equal to 1 then final_u = u; else final_u = (-A - u) mod p
-                            <vspace/>(note: final_u is the Montgomery u-coordinate of the output; see note below on how to compute it)</t>
-                        <t>y_coordinate = (final_u - 1) / (final_u + 1) mod p
-                            <vspace/>(note 1: y_coordinate is the Edwards coordinate corresponding to final_u)
-                            <vspace/>(note 2: the inverse of (final_u + 1) modulo p is guaranteed to exist)</t>
-                        <t>y_string = int_to_string (y_coordinate, 32)</t>
-                        <!--<t>Form an octet string encoding of an elliptic curve point out of y_coordinate and x0, as follows:
-                            <list style="letters">
-                                <t>y_string = int_to_string (y_coordinate, 32)</t>
-                                <t>y_string[31] = y_string[31] | x0 [TODO: should we do this? hash-to-curve draft doesn't]
-                                    <vspace/>(where | denotes the bit-wise OR)</t>
-                            </list>
-                        </t>-->
-                        <t>H_prelim = string_to_point(y_string)
-                        <vspace/> (note: string_to_point will not return INVALID by correctness of Elligator2)</t>
-                        <t>Set H = cofactor * H_prelim</t>
-                        <t>Output H</t>
-                    </list>
-                </t>
-                
-                
-                <t> In order to make this algorithm run in time that is (almost) independent
-                    of the input alpha_string (so-called "constant-time"), implementers should pay particular attention
-                    to Steps 10 and 11 above.
-                    These steps can be implemented using the following approach:
+
+            <section title="ECVRF_hash_to_curve_h2csuite" anchor="h2csuite">
+
+            <t>The ECVRF_hash_to_curve_h2csuite(suite_string, Y, alpha_string) algorithm
+                implements ECVRF_hash_to_curve using
+                a hash-to-curve suite as defined in
+                <xref target="I-D.irtf-cfrg-hash-to-curve"/>.
+            </t>
+
+            <t>
+                ECVRF_hash_to_curve_h2csuite(suite_string, Y, alpha_string)
+            </t>
+            <t>
+                Input:
                 <list>
-                    <t> e = w ^ ((p-1)/2) mod p</t>
-                    <t>final_u = (e*u + (e-1) * (A/2)) mod p</t>
+                    <t>suite_string - a single octet specifying ECVRF ciphersuite. </t>
+                    <t>alpha_string - value to be hashed, an octet string</t>
+                    <t>Y - public key, an EC point</t>
                 </list>
-                The first step will produce a value e that is either 1 or p-1 (it is guaranteed not to be any other value, because w is guaranteed to be nonzero). Implementers should also ensure that the second step
-                runs in the same amount of time regardless of e by ensuring that
-                arithmetic in constant time.
-                </t>
-                
-                <t>
-                Alternatively, let CMOV(result_if_1, result_if_0, selector) be the function that returns result_if_1 when
-                selector is 1 and  result_if_0 when selector is 0. If CMOV is implemented in constant time, then steps 12 and 13 above can be implemented as follows:
+            </t>
+            <t>
+                Output:
                 <list>
-                    <t>e = (w^((p-1)/2))+1 mod p</t>
-                    <t>b = e/2</t>
-                    <t>other_u = (-A-u) mod p</t>
-                    <t>final_u = CMOV(u, other_u, b)</t>
+                    <t>H - hashed value, a finite EC point in G
+                    </t>
                 </list>
-                (Note that after the first step, e is either 0 or 2, and only the least significant byte of e is needed in the second step).
-                CMOV can be implemented in constant time a variety of ways; for example, by expanding b from a single bit to an all-0 or all-1 string (accomplished by negating b in standard two's-complement arithmetic) and then applying bitwise XOR and AND operations as follows: other_x XOR ((x XOR other_x) AND b)
-                </t>
-                <t>
-                    If having this algorithm run in constant time is not important, then there are much faster algorithms
-                    to compute the Legendre symbol (which is the same as the Jacobi symbol because p is a prime).
-                    See, for example, Section 12.3 of <xref target="ntb"/>.
-                </t>
-                
+            </t>
+            <t>
+                Fixed options (specified in <xref target="suites"/>):
+                <list>
+                    <t>h2cSuite - a hash-to-curve suite ID (see discussion below)</t>
+                </list>
+            </t>
+            <t>
+                Steps
+                <list style="numbers">
+                    <t>PK_string = point_to_string(Y)</t>
+                    <t>one_string = 0x01 = int_to_string(1, 1)
+                    <vspace/>(a single octet with value 1) </t>
+                    <t>string_to_hash = suite_string || one_string || PK_string || alpha_string</t>
+                    <t>H = encode(string_to_hash)
+                    <vspace/>(the encode function is discussed below) </t>
+                    <t>Output H</t>
+                </list>
+            </t>
+            <t>The encode function is provided by the hash-to-curve suite whose ID is h2cSuite.
+                For more details, see <xref target="I-D.irtf-cfrg-hash-to-curve"/>, Section 8.
+                The domain separation tag DST, a parameter to the hash-to-curve suite, is
+            </t>
+            <t>
+            "ECVRF_" || suite_string || "_" || h2csuite_string || "_"
+            </t>
+            <t>
+                where "ECVRF_" and "_" are ASCII string literals,
+                suite_string is a single octet,
+                and h2csuite_string is the ASCII encoding of the h2cSuite option value.
+            </t>
             </section>
-            
-            <section title="ECVRF_hash_to_curve_Simplified_SWU" anchor="SimpleSWU">
-                
-                <t> The following ECVRF_hash_to_curve_Simplified_SWU(suite_string, Y, alpha_string)
-                    algorithm implements ECVRF_hash_to_curve using the simplified Shallue-Woestijne <xref target="SW06"/> and Ulas <xref target="Ulas07"/>
-                    algorithm from Section 7 of <xref target="BCIMRT10"/> (see also <xref target="I-D.irtf-cfrg-hash-to-curve"/>).  It can be implemented with running time that is independent of the input alpha (so-called "constant-time"). Generally,
-                    this method can be used
-                    for any curve with prime p that is congruent
-                    to 3 modulo 4; however, the (very unlikely) case of d=0 in step 6 below may need to be handled differently depending on the curve equation, to ensure that the result is a point on the curve.
-                </t>
-                
-                <t>
-                    ECVRF_hash_to_curve_Simplified_SWU(suite_string, Y, alpha_string)
-                </t>
-                <t>
-                    Input:
-                    <list>
-                        <t>suite_string - a single octet specifying ECVRF ciphersuite. </t>
-                        <t>alpha_string - value to be hashed, an octet string</t>
-                        <t>Y - public key, an EC point</t>
-                    </list>
-                </t>
-                <t>
-                    Output:
-                    <list>
-                        <t>H - hashed value, a finite EC point in G
-                        </t>
-                    </list>
-                </t>
-                
-                <t> Fixed options:
-                    <list>
-                        <t> a and b, constants for the Weierstrass form elliptic curve equation y^2 = x^3 + ax +b for the curve E</t>
-                    </list>
-                </t>
-                <t>
-                    Steps:
-                    <list style="numbers">
-                        <t>PK_string = EC2OSP(Y)</t>
-                        <t>one_string = 0x01 = I2OSP(1, 1), a single octet with value 1 </t>
-                        <t>t_string = Hash(suite_string || one_string || PK_string || alpha_string)</t>
-                        <t>t = string_to_int(t_string) mod p</t>
-                        <t>r = -(t^2) mod p</t>
-                        <t>d = (r^2 + r) mod p
-                            <vspace/>(d is t^4-t^2 mod p)</t>
-                        <t>If d = 0 then d_inverse = 0; else d_inverse = 1/d mod p
-                            <vspace/>(as long as Hash is secure, the case of d = 0 is an utterly improbably occurrence;
-                            <vspace/>the two cases can be combined into one by computing d_inverse = d^(p-2) mod p)</t>
-                        <t>x = ((-b/a) * (1 + d_inverse)) mod p</t>
-                        <t>w = (x^3 + a*x + b) mod p
-                        <vspace/>(this step evaluates the curve equation)</t>
-                        <t>Let e equal the Legendre symbol of w and p
-                        <vspace/>(see note below on how to compute e)</t>
-                        <t>If e is equal to 0 or 1 then final_x = x; else final_x = r * x mod p
-                            <vspace/>(final_x is the x-coordinate of the output; see note below on how to compute it)</t>
-                        <t>H_prelim = arbitrary_string_to_point(int_to_string(final_x, 2n))
-                            <vspace/> (note: arbitrary_string_to_point will not return INVALID by correctness of Simple SWU)</t>
-                        <t>If cofactor > 1, set H = cofactor * H; else set H = H_prelim</t>
-                        <t>Output H</t>
-                    </list>
-                </t>
-                
-                
-                <t> In order to make this algorithm run in time that is (almost) independent
-                    of the input (so-called "constant-time"), implementers should pay particular attention
-                    to Steps 10 and 11 above.
-                    These steps can be implemented using the following approach.
-                    Let CMOV(result_if_1, result_if_0, selector) be the function that returns result_if_1 when
-                    selector is 1 and  result_if_0 when selector is 0. If arithmetic and CMOV are implemented in constant time, then steps 9 and 10 above can be implemented as follows:
-                    <list>
-                        <t>e = (w ^ ((p-1)/2))+1 mod p
-                        <vspace />(At this point, e is 0, 1, or 2, as an integer.)</t>
-                        <t>Let b = (e+1) / 2, where / denotes integer division with rounding down.
-                        <vspace />(Note carefully that this step is integer, not modular, division. Only the last byte of e is needed for this step. This step converts 0, 1, or 2 to 0 or 1.)</t>
-                        <t>other_x = r * x mod p</t>
-                        <t>final_x = CMOV(x, other_x, b)</t>
-                    </list>
-                    CMOV can be implemented in constant time a variety of ways; for example, by expanding b from a single bit to an all-0 or all-1 string (accomplished by negating b in standard two's-complement arithmetic) and then applying bitwise XOR and AND operations as follows: other_x XOR ((x XOR other_x) AND b)
-                </t>
-                <t>
-                    If having this algorithm run in constant time is not important, then there are much faster algorithms
-                    to compute the Legendre symbol (which is the same as the Jacobi symbol because p is a prime).
-                    See, for example, Section 12.3 of <xref target="ntb"/>.
-                </t>
-                
-            </section>
-            
+
         </section>
         <section title="ECVRF Nonce Generation" anchor="ecvrfNonceGeneration">
         
@@ -1254,8 +1106,9 @@
             
             <list style="symbols">
                 <t> This ciphersuite is identical to ECVRF-P256-SHA256-TAI except that
-                    the ECVRF_hash_to_curve function is as specified in <xref target="SimpleSWU"/> and
-                    suite_string = 0x02 = int_to_string(2, 1).
+                    the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
+                    with h2cSuite = P256-SHA256-SSWU-NU-
+                    and suite_string = 0x02 = int_to_string(2, 1).
                 </t>
             </list>
         </t>
@@ -1314,8 +1167,14 @@
     
         <list style="symbols">
         <t> This ciphersuite is identical to ECVRF-EDWARDS25519-SHA512-TAI except that
-        the ECVRF_hash_to_curve function is as specified in <xref target="elligator2"/> and 
-        suite_string = 0x04 = int_to_string(4, 1).
+            the ECVRF_hash_to_curve function is as specified in <xref target="h2csuite"/>
+            with h2cSuite = edwards25519-SHA512-EDELL2-NU-
+            and suite_string = 0x04 = int_to_string(4, 1).
+        </t>
+        <t>
+            The suite edwards25519-SHA512-EDELL2-NU- is identical to the suite
+            edwards25519-SHA256-EDELL2-NU- defined in <xref target="I-D.irtf-cfrg-hash-to-curve"/>,
+            Section 8, except that the hash function H is SHA-512 rather than SHA-256.
         </t>
         </list>
         </t>
@@ -1927,7 +1786,7 @@
 
         <?rfc include="reference.I-D.vcelak-nsec5.xml"?>
 
-        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-01.xml"?>
+        <?rfc include="reference.I-D.draft-irtf-cfrg-hash-to-curve-05.xml"?>
 
     <reference anchor = "ANSI.X9-62-2005">
         <front>


### PR DESCRIPTION
Hello! I'm helping with the hash-to-durve Internet draft, and I've been chatting with @reyzin about harmonizing our two documents.

To that end, this PR removes the step-by-step descriptions of Elligator 2 and Simplified SWU, and replaces them with references to [hash-to-curve](cfrg/draft-irtf-cfrg-hash-to-curve) ciphersuites.

We (the hash-to-curve authors) are just about ready to push revision -05. This PR preemptively refers to that version of the document, which means xml2rfc will die until the -05 draft is actually published---sorry about that.

Happy to coordinate further, make changes, etc. Please let me know how I can help!